### PR TITLE
make poll_wait public so it can be reused to implement futures

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -49,7 +49,7 @@ mod atomic_notification {
             poll_fn(move |cx| self.poll_wait(cx))
         }
 
-        fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<()> {
+        pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<()> {
             self.waker.register(cx.waker());
 
             if self.triggered.swap(false, Ordering::SeqCst) {


### PR DESCRIPTION
impl future's wait returns a Poll::Ready/Pending.
By exposing this, we can use it as part of implementing Futures for various things.

In particular, this is necessary to reuse it as part of implementing pin InputFuture's over in esp-idf-hal.
