### PR TITLE
Embedded svc afit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ embassy-sync = { version = "0.2", optional = true }
 embedded-io = { version = "0.4", default-features = false, optional = true }
 embedded-svc = { version = "0.25", default-features = false, optional = true }
 edge-net = { version = "0.3", default-features = false, features = ["nightly", "embassy-util", "embedded-svc"], optional = true }
+
+[patch.crates-io]
+embedded-svc = { git = "https://github.com/esp-rs/embedded-svc", rev = "8c6f9d6" }

--- a/src/asynch/pubsub.rs
+++ b/src/asynch/pubsub.rs
@@ -147,7 +147,7 @@ pub mod embedded_svc_impl {
 
         pub async fn recv(&mut self) -> D
         where
-            R: embedded_svc::event_bus::asynch::Receiver<Data = D>,
+            R: embedded_svc::event_bus::asynch::Receiver<Result = D>,
         {
             self.0.recv().await
         }
@@ -155,7 +155,7 @@ pub mod embedded_svc_impl {
 
     impl<R, D> crate::asynch::Receiver for SvcReceiver<R, D>
     where
-        R: embedded_svc::event_bus::asynch::Receiver<Data = D>,
+        R: embedded_svc::event_bus::asynch::Receiver<Result = D>,
     {
         type Error = Infallible;
 


### PR DESCRIPTION
New AFIT branch in embedded_svc has renamed the associated type for `embedded_svc::event_bus::asynch::Receiver` from `Data` to `Result`, and this was causing compilation to fail for `mod pubsub`.

Draft PR because this is mostly just here for reference if anyone else is using this crate with the latest commit from the embedded-svc repo and wants a quick fix. The fix is so small that I'm sure @ivmarkov will do it himself after the next embedded-svc release. 